### PR TITLE
fix: update Netlify CMS configuration

### DIFF
--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -270,6 +270,7 @@ collections:
         time_format: false 
       - name: ingredients
         label: Ingredients
+        label_singular: Ingredient
         widget: list
         fields:
           - name: title


### PR DESCRIPTION
- correct Ingredient singular label in Recipes collection